### PR TITLE
proxy support

### DIFF
--- a/AdKatsLRT.cs
+++ b/AdKatsLRT.cs
@@ -4938,11 +4938,15 @@ namespace PRoConEvents {
     public class GZipWebClient : WebClient {
         private String ua;
         private bool compress;
-
-        public GZipWebClient(String ua = "Mozilla/5.0 (compatible; PRoCon 1; AdKats)", bool compress = true) {
-            this.ua = ua;
-            this.compress = compress;
+        
+        public GZipWebClient() {
+            this.ua = "Mozilla/5.0 (compatible; PRoCon 1; AdKatsLRT)";
             base.Headers["User-Agent"] = ua;
+            compress = true;
+        }
+
+        public GZipWebClient(bool compress) : this() {
+            this.compress = compress;
         }
 
         public string GZipDownloadString(string address) {

--- a/AdKatsLRT.cs
+++ b/AdKatsLRT.cs
@@ -396,8 +396,10 @@ namespace PRoConEvents {
                     } 
                 } else if (Regex.Match(strVariable, @"Proxy URL").Success) {
                     try {
-                        Uri uri = new Uri(strValue);
-                        Log.Debug("Proxy URL set to " + strValue + ".", 1);
+                        if (!String.IsNullOrEmpty(strValue)) {
+                            Uri uri = new Uri(strValue);
+                            Log.Debug("Proxy URL set to " + strValue + ".", 1);
+                        }
                     }
                     catch (UriFormatException) {
                         strValue = _proxyURL;

--- a/AdKatsLRT.cs
+++ b/AdKatsLRT.cs
@@ -2015,7 +2015,7 @@ namespace PRoConEvents {
                     Log.Error("Attempted to get battlelog information of nameless player.");
                     return;
                 }
-                using (var client = new WebClient()) {
+                using (var client = new GZipWebClient()) {
                     if (_useProxy && !String.IsNullOrEmpty(_proxyURL)) {
                         client.Proxy = new WebProxy(_proxyURL, true); 
                     }
@@ -3182,7 +3182,7 @@ namespace PRoConEvents {
         private Hashtable FetchWarsawLibrary() {
             Hashtable library = null;
             try {
-                using (var client = new WebClient()) {
+                using (var client = new GZipWebClient()) {
                     String response;
                     try {
                         response = client.DownloadString("https://raw.githubusercontent.com/AdKats/AdKats/master/lib/WarsawCodeBook.json");
@@ -3754,7 +3754,7 @@ namespace PRoConEvents {
         private Hashtable FetchPlayerLoadout(String personaID) {
             Hashtable loadout = null;
             try {
-                using (var client = new WebClient()) { 
+                using (var client = new GZipWebClient()) { 
                     if (_useProxy && !String.IsNullOrEmpty(_proxyURL)) { 
                         client.Proxy = new WebProxy(_proxyURL, true); 
                     }
@@ -4928,6 +4928,24 @@ namespace PRoConEvents {
             public String CGrey(String msg) {
                 return "^9" + msg + "^0";
             }
+        }
+    }
+    
+    public class GZipWebClient : WebClient
+    {
+        private String ua;
+    
+        public GZipWebClient(String ua = "Mozilla/5.0 (compatible; PRoCon 1; AdKatsLRT)")
+        {
+            this.ua = ua;
+        }
+        
+        protected override WebRequest GetWebRequest(Uri address)
+        {
+            HttpWebRequest request = (HttpWebRequest)base.GetWebRequest(address);
+            request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            request.UserAgent = ua;
+            return request;
         }
     }
 }


### PR DESCRIPTION
This pull request would do the following:
* Raise the version by 1
* Add two settings (Enable Proxy for Battlelog, Proxy URL) + Validation
* Add a WebProxy to 2 WebClients if the setting is enabled and a valid proxy is set.

Also I create a new WebProxy object on every new request. Did not want to cache it somewhere as a member, or make it static.

Reason:
Battlelog has been having a 20 requests / minute / per IP (or smth like that) since the last weekend. I bypass this limit by sending all requests to battlelog through a round robin proxy provider. Maybe this might be helpful for others?

Tested and working.